### PR TITLE
implemented add() override for CGridLayout

### DIFF
--- a/qtstrap/widgets/layouts.py
+++ b/qtstrap/widgets/layouts.py
@@ -142,7 +142,12 @@ class CHBoxLayout(ContextLayout, QHBoxLayout):
 
 
 class CGridLayout(ContextLayout, QGridLayout):
-    ...
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def add(self, item: QWidget, *args, rowspan: int=1, colspan: int=1, **kwargs):
+        self.addWidget(item, *args, rowspan, colspan, **kwargs)
+        return item
 
 
 class CFormLayout(ContextLayout, QFormLayout):


### PR DESCRIPTION
I provided `CGridLayout` with an `add()` implementation. This hopefully makes additions to `QGridLayout`s more explicit in cases where widgets span multiple rows and/ or columns.

before:

```python
with CGridLayout(self) as layout:
    layout.addWidget(mywidget, 0, 0, 1, 2)
```

after:

```python
with CGridLayout(self) as layout:
    layout.add(mywidget, 0, 0, rowspan=1, colspan=2)
```